### PR TITLE
Updated voices comboboxes with labels matching those from MuseScore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # MuseScore_UltraStar_Exporter
 This plugin exports the lyrics and the music of a score into the UltraStar format.
-UltraStar is free program similar to SingStar. Other programs use the UltraStar format as well, such as the open source Performous.
+[UltraStar](http://ultrastardx.sourceforge.net/) is free program similar to [SingStar](https://www.singstar.com/en_US/about.html). Other programs use the UltraStar format as well, such as the open source [Performous](http://performous.org/).
 
 These programs generally attempt to match lyrics and tone notations to an existing mp3 recording of a song. The basic idea of these kinds of games looks like it would work well for practicing, but the existing mp3 files are usually the original song from the original artist. While this works well when singing just for fun, it makes it difficult for the singer to really learn from his performance.
 
-This plugin requires functions only found the latest nightly builds of MuseScore, and will not run if it encounters a MuseScore version below 2.1.0.
+This plugin requires MuseScore 2.0.1 or above.
 
 Features:
-Export of the musical score to an mp3 file.
-Export of the required .txt file for UltraStar.
-Export for Duet is implemented but untested.
-Selection of the Instrument and Voice to be used for the lyrics for player 1 and player 2.
-Annotator to mark line breaks and golden or freestyle notes.
+* Export of the musical score to an mp3 file.
+* Export of the required .txt file for UltraStar.
+* Export for Duet is implemented but mostly untested.
+* Selection of the Instrument and Voice to be used for the lyrics for player 1 and player 2.
+* Annotator to mark line breaks and golden or freestyle notes.
 
 Usage:
+
 1. Enter the score of the song - do NOT use repeats, as MuseScore doesn't unroll them when making the mp3.
-2. Mark line breaks by selecting a note and pressing CTRL T for a Staff Text. Enter a / to indicate a line break.
-3. Mark a golden note by selecting a note and pressing CTRL T for a Staff Text. Enter a * to indicate a golden note.
-4. Mark a freestyle note by selecting a note and pressing CTRL T for a Staff Text. Enter a F to indicate a freestyle note.
+2. Mark line breaks by selecting a note and pressing `CTRL+T` for a Staff Text. Enter a `/` to indicate a line break.
+3. Mark a golden note by selecting a note and pressing `CTRL+T` for a Staff Text. Enter a `*` to indicate a golden note.
+4. Mark a freestyle note by selecting a note and pressing `CTRL+T` for a Staff Text. Enter a `F` to indicate a freestyle note.
 5. The export function sets the UltraStar notations to invisible - to see them again, select "Show Invisible" from the "View" menu. The notations are hidden so as not to clutter up the printout. When "Show invisible" is active, you can edit the notations as needed.
 
 Alternatively, use the Annotator (Menu View/UltraStar Annotator.) Select a note with Shift and Left mouse button - draw a box around the note. Click the appropriate button to add the annotation.
 
 Make sure to select the correct instrument when exporting.
 
-The plugin has not been tested under Windows since I use Linux.
+The plugin has been tested under Windows7 against release 2.0.2 and Linux.

--- a/UltrastarExport.qml
+++ b/UltrastarExport.qml
@@ -44,8 +44,8 @@ MuseScore {
         loadInstrumentList(staffList)
         instrumentPlayer1.model = staffList
         instrumentPlayer2.model = staffList
-        loadVoiceList(instrumentPlayer1.currentText, player1Voices)
-        loadVoiceList(instrumentPlayer2.currentText, player2Voices)
+        loadVoiceList(instrumentPlayer1.currentText, player1Voices, voicePlayer1)
+        loadVoiceList(instrumentPlayer2.currentText, player2Voices, voicePlayer2)
         directorySelectDialog.folder = exportDirectory.text
         //exportDirectory.text = directorySelectDialog.fileUrl.toString().replace(
         // "file://", "")
@@ -60,18 +60,18 @@ MuseScore {
         }
     }
 
-    function loadVoiceList(instrumentName, voiceList) {
+    function loadVoiceList(instrumentName, voiceList, voiceCombo) {
         for (var i = 0; i < curScore.parts.length; i++) {
             if (curScore.parts[i].partName === instrumentName) {
-                voiceList.clear()
-                for (var j = 0; j < curScore.parts[i].endTrack
-                     - curScore.parts[i].startTrack; j++) {
-                    voiceList.append({
-                                         j: j
-                                     })
+                voiceList.clear();
+                for (var j = 0; j < (curScore.parts[i].endTrack - curScore.parts[i].startTrack); j++) {
+                    voiceList.append({ j: qsTr("Voice" + ' ' + (j + 1)) });
                 }
             }
         }
+        voiceCombo.model = voiceList; //applying the new list sets currentIndex to 0, but doesn't update the shown comboboxText
+        voiceCombo.currentIndex = 1;  //force an indexChange to force the combo to update its label
+        voiceCombo.currentIndex = 0;  //force indexChange back to default, now the label will be updated
     }
 
     Settings {
@@ -174,8 +174,7 @@ MuseScore {
                     ComboBox {
                         id: instrumentPlayer1
                         onCurrentIndexChanged: {
-                            loadVoiceList(currentText, player1Voices)
-                            voicePlayer1.model = player1Voices
+                            loadVoiceList(currentText, player1Voices, voicePlayer1)
                         }
                     }
                     Label {
@@ -206,8 +205,7 @@ MuseScore {
                     ComboBox {
                         id: instrumentPlayer2
                         onCurrentIndexChanged: {
-                            loadVoiceList(currentText, player2Voices)
-                            voicePlayer2.model = player2Voices
+                            loadVoiceList(currentText, player2Voices, voicePlayer2)
                         }
                     }
                     Label {

--- a/UltrastarExport.qml
+++ b/UltrastarExport.qml
@@ -63,7 +63,7 @@ MuseScore {
             if (curScore.parts[i].partName === instrumentName) {
                 voiceList.clear();
                 for (var j = 0; j < (curScore.parts[i].endTrack - curScore.parts[i].startTrack); j++) {
-                    voiceList.append({ j: qsTr("Voice" + ' ' + (j + 1)) });
+                    voiceList.append({ j: (j + 1) });
                 }
             }
         }

--- a/UltrastarExport.qml
+++ b/UltrastarExport.qml
@@ -44,8 +44,8 @@ MuseScore {
         loadInstrumentList(staffList)
         instrumentPlayer1.model = staffList
         instrumentPlayer2.model = staffList
-        loadVoiceList(instrumentPlayer1.currentText, player1Voices)
-        loadVoiceList(instrumentPlayer2.currentText, player2Voices)
+        loadVoiceList(instrumentPlayer1.currentText, player1Voices, voicePlayer1)
+        loadVoiceList(instrumentPlayer2.currentText, player2Voices, voicePlayer2)
         directorySelectDialog.folder = ((Qt.platform.os=="windows")? "file:///" : "file://") + exportDirectory.text;
     }
 
@@ -58,18 +58,18 @@ MuseScore {
         }
     }
 
-    function loadVoiceList(instrumentName, voiceList) {
+    function loadVoiceList(instrumentName, voiceList, voiceCombo) {
         for (var i = 0; i < curScore.parts.length; i++) {
             if (curScore.parts[i].partName === instrumentName) {
-                voiceList.clear()
-                for (var j = 0; j < curScore.parts[i].endTrack
-                     - curScore.parts[i].startTrack; j++) {
-                    voiceList.append({
-                                         j: j
-                                     })
+                voiceList.clear();
+                for (var j = 0; j < (curScore.parts[i].endTrack - curScore.parts[i].startTrack); j++) {
+                    voiceList.append({ j: qsTr("Voice" + ' ' + (j + 1)) });
                 }
             }
         }
+        voiceCombo.model = voiceList; //applying the new list sets currentIndex to 0, but doesn't update the shown comboboxText
+        voiceCombo.currentIndex = 1;  //force an indexChange to force the combo to update its label
+        voiceCombo.currentIndex = 0;  //force indexChange back to default, now the label will be updated
     }
 
     Settings {
@@ -165,8 +165,7 @@ MuseScore {
                     ComboBox {
                         id: instrumentPlayer1
                         onCurrentIndexChanged: {
-                            loadVoiceList(currentText, player1Voices)
-                            voicePlayer1.model = player1Voices
+                            loadVoiceList(currentText, player1Voices, voicePlayer1)
                         }
                     }
                     Label {
@@ -197,8 +196,7 @@ MuseScore {
                     ComboBox {
                         id: instrumentPlayer2
                         onCurrentIndexChanged: {
-                            loadVoiceList(currentText, player2Voices)
-                            voicePlayer2.model = player2Voices
+                            loadVoiceList(currentText, player2Voices, voicePlayer2)
                         }
                     }
                     Label {


### PR DESCRIPTION
Text keys for voices now match the ones used for translating MuseScore ([from the Dutch translation index](https://www.transifex.com/musescore/musescore/viewstrings/#nl/musescore/20440840?q=voice)). This should benefit us in the future when [plugins leverage existing translations](https://musescore.org/en/node/91856) and be more user friendly.

Also fixes auto-updating of the textlabels upon changing instrument selection.
