### PR TITLE
Processing tied notes as if they are a single duration entry

### DIFF
--- a/UltrastarExport.qml
+++ b/UltrastarExport.qml
@@ -356,6 +356,23 @@ MuseScore {
                 duration_midi_ticks = calculateMidiTicksfromTicks(cursor.element.duration.ticks);
                 timestamp_midi_ticks = calculateMidiTicksfromTicks(cursor.tick);
 
+                while (cursor.element.notes[0].tieFor != null) {//note is tied to the next one, increment duration
+                    do { //move to next note
+                        cursor.next();
+                    } while (
+                        cursor.segment
+                    && (   !cursor.element
+                        || (cursor.element.type !== Element.CHORD)
+                        )
+                    );
+                    //are we still valid and found the end of the tie?
+                    if (cursor.segment && cursor.element && (cursor.element.type === Element.CHORD)
+                        && (cursor.element.notes[0].tieBack != null)
+                        ) {
+                        duration_midi_ticks += calculateMidiTicksfromTicks(cursor.element.duration.ticks);
+                    }
+                }
+
                 if (!gotfirstsyllable) {
                     gotfirstsyllable = true
                 }


### PR DESCRIPTION
Resulting note is the first note of the tie, with a prolonged duration as long as the note is tied.
Tested with the following note entry:
![ultrastar_tie_processing](https://cloud.githubusercontent.com/assets/895153/12401989/59f18cee-be2a-11e5-8f89-ba1b07a33bb9.png)
